### PR TITLE
Don't import StringIO or smart_text from rest_framework.compat.

### DIFF
--- a/rest_framework_xml/renderers.py
+++ b/rest_framework_xml/renderers.py
@@ -5,7 +5,8 @@ from __future__ import unicode_literals
 
 from django.utils import six
 from django.utils.xmlutils import SimplerXMLGenerator
-from rest_framework.compat import StringIO, smart_text
+from django.utils.six.moves import StringIO
+from django.utils.encoding import smart_text
 from rest_framework.renderers import BaseRenderer
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -5,7 +5,7 @@ import datetime
 
 from django.test import TestCase
 from django.utils import unittest
-from rest_framework.compat import StringIO
+from django.utils.six.moves import StringIO
 from rest_framework_xml.parsers import XMLParser
 from rest_framework_xml.compat import etree
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 from django.test import TestCase
 from django.utils import unittest
-from rest_framework.compat import StringIO
+from django.utils.six.moves import StringIO
 from rest_framework_xml.renderers import XMLRenderer
 from rest_framework_xml.parsers import XMLParser
 from rest_framework_xml.compat import etree

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django{1.6,1.7}-drf{2.4.3,2.4.4,3.0}
+       {py27,py33,py34}-django{1.6,1.7}-drf{2.4.3,2.4.4,3.0.0}
 
 [testenv]
 commands = ./runtests.py --fast


### PR DESCRIPTION
Fixes #3.

I had to make a small change to tox.ini to get it to run. Should that be updated to 3.0.4?