### PR TITLE
Test newer Django and DRF versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django{1.6,1.7}-drf{2.4.3,2.4.4,3.0.0}
+       {py27,py33,py34}-django{1.6,1.7,1.8}-drf{2.4.3,2.4.4,3.0.0,3.1.3}
 
 [testenv]
 commands = ./runtests.py --fast
@@ -9,11 +9,13 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
        django1.6: Django==1.6.8
-       django1.7: Django==1.7.1
+       django1.7: Django==1.7.8
+       django1.8: Django==1.8.2
        drf2.4.3: djangorestframework==2.4.3
        drf2.4.4: djangorestframework==2.4.4
        drf3.0.0: djangorestframework==3.0.0
-       pytest-django==2.6.1
+       drf3.1.3: djangorestframework==3.1.3
+       pytest-django==2.8.0
 
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly


### PR DESCRIPTION
Add DRF 3.1.x and Django 1.8 to tests
* Updated pytest-django to work with Django 1.8
* Test with latest 1.7.x release