### PR TITLE
Allow list-item tag name to be customised

### DIFF
--- a/rest_framework_xml/renderers.py
+++ b/rest_framework_xml/renderers.py
@@ -18,6 +18,7 @@ class XMLRenderer(BaseRenderer):
     media_type = 'application/xml'
     format = 'xml'
     charset = 'utf-8'
+    item_tag_name = 'list-item'
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         """
@@ -41,9 +42,9 @@ class XMLRenderer(BaseRenderer):
     def _to_xml(self, xml, data):
         if isinstance(data, (list, tuple)):
             for item in data:
-                xml.startElement("list-item", {})
+                xml.startElement(self.item_tag_name, {})
                 self._to_xml(xml, item)
-                xml.endElement("list-item")
+                xml.endElement(self.item_tag_name)
 
         elif isinstance(data, dict):
             for key, value in six.iteritems(data):

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -91,6 +91,12 @@ class XMLRendererTestCase(TestCase):
         self.assertXMLContains(content, '<sub_name>first</sub_name>')
         self.assertXMLContains(content, '<sub_name>second</sub_name>')
 
+    def test_render_list(self):
+        renderer = XMLRenderer()
+        content = renderer.render(self._complex_data, 'application/xml')
+        self.assertXMLContains(content, '<sub_data_list><list-item>')
+        self.assertXMLContains(content, '</list-item></sub_data_list>')
+
     @unittest.skipUnless(etree, 'defusedxml not installed')
     def test_render_and_parse_complex_data(self):
         """


### PR DESCRIPTION
I think it's nice to be able to override this... especially as the hyphenation doesn't fit well with underscored model field names.