### PR TITLE
added functionality to correctly parse xml lists

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 Django>=1.6
 djangorestframework>=2.4.3
-pytest-django==2.6
+pytest-django==2.9.1
 pytest==2.5.2
 pytest-cov==1.6
 flake8==2.2.2

--- a/rest_framework_xml/parsers.py
+++ b/rest_framework_xml/parsers.py
@@ -37,6 +37,13 @@ class XMLParser(BaseParser):
 
         return data
 
+    def _check_xml_list(self, element):
+        """
+        Checks that an element has multiple tags and that they are all the same, 
+        to validate that the element is a properly formatted list
+        """
+        return len(element) > 1 and len(set([child.tag for child in element])) <= 1
+
     def _xml_convert(self, element):
         """
         convert the xml `element` into the corresponding python object
@@ -48,7 +55,7 @@ class XMLParser(BaseParser):
             return self._type_convert(element.text)
         else:
             # if the fist child tag is list-item means all children are list-item
-            if children[0].tag == "list-item":
+            if self._check_xml_list(element):
                 data = []
                 for child in children:
                     data.append(self._xml_convert(child))

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -4,7 +4,6 @@ import datetime
 
 
 from django.test import TestCase
-from django.utils import unittest
 from django.utils.six.moves import StringIO
 from rest_framework_xml.parsers import XMLParser
 from rest_framework_xml.compat import etree
@@ -52,15 +51,66 @@ class TestXMLParser(TestCase):
                 }
             ]
         }
+        self._invalid_list_input = StringIO(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<root>'
+            '<list>'
+            '<list-item><sub_id>1</sub_id><sub_name>first</sub_name></list-item>'
+            '<list-item2><sub_id>2</sub_id><sub_name>second</sub_name></list-item2>'
+            '<list-item2><sub_id>3</sub_id><sub_name>third</sub_name></list-item2>'
+            '</list>'
+            '</root>'
+        )
+        self._invalid_list_output = {
+            "list": {
+                "list-item": {
+                    "sub_id": 1,
+                    "sub_name": "first"
+                },
+                "list-item2": {
+                    "sub_id": 3,
+                    "sub_name": "third"
+                }
+            }
+        }
+        self._valid_list_input = StringIO(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<root>'
+            '<list>'
+            '<list-item><sub_id>1</sub_id><sub_name>first</sub_name></list-item>'
+            '<list-item><sub_id>2</sub_id><sub_name>second</sub_name></list-item>'
+            '</list>'
+            '</root>'
+        )
+        self._valid_list_output = {
+            "list": [
+                {
+                    "sub_id": 1,
+                    "sub_name": "first"
+                },
+                {
+                    "sub_id": 2,
+                    "sub_name": "second"
+                }
+            ]
+        }
 
-    @unittest.skipUnless(etree, 'defusedxml not installed')
     def test_parse(self):
         parser = XMLParser()
         data = parser.parse(self._input)
         self.assertEqual(data, self._data)
 
-    @unittest.skipUnless(etree, 'defusedxml not installed')
     def test_complex_data_parse(self):
         parser = XMLParser()
         data = parser.parse(self._complex_data_input)
         self.assertEqual(data, self._complex_data)
+
+    def test_invalid_list_parse(self):
+        parser = XMLParser()
+        data = parser.parse(self._invalid_list_input)
+        self.assertEqual(data, self._invalid_list_output)
+
+    def test_valid_list_parse(self):
+        parser = XMLParser()
+        data = parser.parse(self._valid_list_input)
+        self.assertEqual(data, self._valid_list_output)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -5,7 +5,6 @@ import datetime
 from decimal import Decimal
 
 from django.test import TestCase
-from django.utils import unittest
 from django.utils.six.moves import StringIO
 from rest_framework_xml.renderers import XMLRenderer
 from rest_framework_xml.parsers import XMLParser
@@ -97,7 +96,6 @@ class XMLRendererTestCase(TestCase):
         self.assertXMLContains(content, '<sub_data_list><list-item>')
         self.assertXMLContains(content, '</list-item></sub_data_list>')
 
-    @unittest.skipUnless(etree, 'defusedxml not installed')
     def test_render_and_parse_complex_data(self):
         """
         Test XML rendering.


### PR DESCRIPTION
### The problem ###

Hello, I am using this library to parse XML in Django REST, and unfortunately, the XML I am parsing is third party, so I cannot use the "list-item" designator. 

### The solution ###

I added a function `_check_xml_list` to check if an XML node represents a list of items. This replaces the check for `children[0].tag == "list-item"`, allowing any list of child nodes that have identical names to be parsed as a list.

The way the function works is that it checks that

1. the element has more than one child node
2. the child nodes all have the same name

If they do not have the same name, then it is treated as a normal dictionary element, and duplicate nodes will be overwritten as before. 

### Testing ###

I added tests to check both valid and invalid lists nodes, which check the behavior described above.

The unit tests would not run with pytest-django 2.6; the error I received was:

`Failed: Database access not allowed, use the "django_db" mark to enable`

Upgrading to pytest-django to the latest, 2.9.1, solved this problem.

I am also using Django 1.9, and `unittest` is no longer a package in `django.utils`, so I removed the references to it. 

I can remove those changes if desired, my main interest is getting this feature pulled in, and I needed to be able to run the tests to make sure that they passed.

### Related issues ###

Here are related issues and a closed PR:

https://github.com/jpadilla/django-rest-framework-xml/issues/5
https://github.com/jpadilla/django-rest-framework-xml/issues/11
https://github.com/jpadilla/django-rest-framework-xml/pull/12