### PR TITLE
Parse zero padded integers as strings

### DIFF
--- a/rest_framework_xml/parsers.py
+++ b/rest_framework_xml/parsers.py
@@ -72,6 +72,9 @@ class XMLParser(BaseParser):
         except ValueError:
             pass
 
+        if value.startswith('0'):
+            return value
+
         try:
             return int(value)
         except ValueError:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 import datetime
 
-
+from decimal import Decimal
 from django.test import TestCase
 from django.test.utils import skipUnless
 from django.utils.six.moves import StringIO
@@ -19,13 +19,17 @@ class TestXMLParser(TestCase):
             '<field_b>dasd</field_b>'
             '<field_c></field_c>'
             '<field_d>2011-12-25 12:45:00</field_d>'
+            '<field_e>121.1</field_e>'
+            '<field_f>0001</field_f>'
             '</root>'
         )
         self._data = {
             'field_a': 121,
             'field_b': 'dasd',
             'field_c': None,
-            'field_d': datetime.datetime(2011, 12, 25, 12, 45, 00)
+            'field_d': datetime.datetime(2011, 12, 25, 12, 45, 00),
+            'field_e': Decimal('121.1'),
+            'field_f': '0001',
         }
         self._complex_data_input = StringIO(
             '<?xml version="1.0" encoding="utf-8"?>'

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -38,8 +38,9 @@ class XMLRendererTestCase(TestCase):
         Test XML rendering.
         """
         renderer = XMLRenderer()
-        content = renderer.render({'field': 'astring'}, 'application/xml')
+        content = renderer.render({'field': 'astring', 'field_b': '0001'}, 'application/xml')
         self.assertXMLContains(content, '<field>astring</field>')
+        self.assertXMLContains(content, '<field_b>0001</field_b>')
 
     def test_render_integer(self):
         """


### PR DESCRIPTION
Thanks for your work in this library! We're considering using it for a project, but one of the things that we run in to is that our users have values in their XML that look (and parse) like integers, but are actually strings. These values look like `<code>000123</code>`.
The parser incorrectly assumes these are integers, and in the process throws away information (the leading zeroes). The renderer works correctly though: the Python-structure `{'code': '000123'}` is rendered correctly to `<code>000123</code>`. So for one, the symmetry between parser and renderer is missing here.

This PR checks if values have a leading zero, and then does no processing at all. In the process I added some more tests to clarify existing behavior.