### PR TITLE
Updated DRF and Python version combinations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ sudo: false
 env:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs
-    - TOX_ENV=py27-django1.7-drf2.4
-    - TOX_ENV=py27-django1.7-drf3.0
-    - TOX_ENV=py27-django1.7-drf3.1
-    - TOX_ENV=py27-django1.7-drf3.2
-    - TOX_ENV=py27-django1.7-drf3.3
     - TOX_ENV=py27-django1.8-drf2.4
     - TOX_ENV=py27-django1.8-drf3.0
     - TOX_ENV=py27-django1.8-drf3.1
@@ -31,11 +26,6 @@ env:
     - TOX_ENV=py27-django1.11-drf3.6
     - TOX_ENV=py27-django1.11-drf3.7
     - TOX_ENV=py27-django1.11-drf3.8
-    - TOX_ENV=py33-django1.7-drf2.4
-    - TOX_ENV=py33-django1.7-drf3.0
-    - TOX_ENV=py33-django1.7-drf3.1
-    - TOX_ENV=py33-django1.7-drf3.2
-    - TOX_ENV=py33-django1.7-drf3.3
     - TOX_ENV=py33-django1.8-drf2.4
     - TOX_ENV=py33-django1.8-drf3.0
     - TOX_ENV=py33-django1.8-drf3.1
@@ -57,11 +47,6 @@ env:
     - TOX_ENV=py33-django1.11-drf3.6
     - TOX_ENV=py33-django1.11-drf3.7
     - TOX_ENV=py33-django1.11-drf3.8
-    - TOX_ENV=py34-django1.7-drf2.4
-    - TOX_ENV=py34-django1.7-drf3.0
-    - TOX_ENV=py34-django1.7-drf3.1
-    - TOX_ENV=py34-django1.7-drf3.2
-    - TOX_ENV=py34-django1.7-drf3.3
     - TOX_ENV=py34-django1.8-drf2.4
     - TOX_ENV=py34-django1.8-drf3.0
     - TOX_ENV=py34-django1.8-drf3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 
@@ -12,7 +11,7 @@ matrix:
   fast_finish: true
 
 install:
-  - pip install tox==2.9.* tox-travis
+  - pip install tox tox-travis
 
 script:
     - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ sudo: false
 env:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-docs
-    - TOX_ENV=py27-django1.6-drf2.4
-    - TOX_ENV=py27-django1.6-drf3.0
-    - TOX_ENV=py27-django1.6-drf3.1
-    - TOX_ENV=py27-django1.6-drf3.2
     - TOX_ENV=py27-django1.7-drf2.4
     - TOX_ENV=py27-django1.7-drf3.0
     - TOX_ENV=py27-django1.7-drf3.1
@@ -35,10 +31,6 @@ env:
     - TOX_ENV=py27-django1.11-drf3.6
     - TOX_ENV=py27-django1.11-drf3.7
     - TOX_ENV=py27-django1.11-drf3.8
-    - TOX_ENV=py33-django1.6-drf2.4
-    - TOX_ENV=py33-django1.6-drf3.0
-    - TOX_ENV=py33-django1.6-drf3.1
-    - TOX_ENV=py33-django1.6-drf3.2
     - TOX_ENV=py33-django1.7-drf2.4
     - TOX_ENV=py33-django1.7-drf3.0
     - TOX_ENV=py33-django1.7-drf3.1
@@ -65,10 +57,6 @@ env:
     - TOX_ENV=py33-django1.11-drf3.6
     - TOX_ENV=py33-django1.11-drf3.7
     - TOX_ENV=py33-django1.11-drf3.8
-    - TOX_ENV=py34-django1.6-drf2.4
-    - TOX_ENV=py34-django1.6-drf3.0
-    - TOX_ENV=py34-django1.6-drf3.1
-    - TOX_ENV=py34-django1.6-drf3.2
     - TOX_ENV=py34-django1.7-drf2.4
     - TOX_ENV=py34-django1.7-drf3.0
     - TOX_ENV=py34-django1.7-drf3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   fast_finish: true
 
 install:
-  - pip install tox tox-travis
+  - pip install tox<3 tox-travis
 
 script:
     - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ python:
   - "3.4"
   - "3.5"
 
-matrix:
-  fast_finish: true
-
 install:
   - pip install tox tox-travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   fast_finish: true
 
 install:
-  - pip install tox<3 tox-travis
+  - pip install tox==2.9.* tox-travis
 
 script:
     - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,82 +2,17 @@ language: python
 
 sudo: false
 
-env:
-    - TOX_ENV=py27-flake8
-    - TOX_ENV=py27-docs
-    - TOX_ENV=py27-django1.8-drf2.4
-    - TOX_ENV=py27-django1.8-drf3.0
-    - TOX_ENV=py27-django1.8-drf3.1
-    - TOX_ENV=py27-django1.8-drf3.2
-    - TOX_ENV=py27-django1.8-drf3.3
-    - TOX_ENV=py27-django1.8-drf3.4
-    - TOX_ENV=py27-django1.8-drf3.5
-    - TOX_ENV=py27-django1.8-drf3.6
-    - TOX_ENV=py27-django1.9-drf3.3
-    - TOX_ENV=py27-django1.9-drf3.4
-    - TOX_ENV=py27-django1.9-drf3.5
-    - TOX_ENV=py27-django1.9-drf3.6
-    - TOX_ENV=py27-django1.10-drf3.4
-    - TOX_ENV=py27-django1.10-drf3.5
-    - TOX_ENV=py27-django1.10-drf3.6
-    - TOX_ENV=py27-django1.10-drf3.7
-    - TOX_ENV=py27-django1.10-drf3.8
-    - TOX_ENV=py27-django1.11-drf3.5
-    - TOX_ENV=py27-django1.11-drf3.6
-    - TOX_ENV=py27-django1.11-drf3.7
-    - TOX_ENV=py27-django1.11-drf3.8
-    - TOX_ENV=py33-django1.8-drf2.4
-    - TOX_ENV=py33-django1.8-drf3.0
-    - TOX_ENV=py33-django1.8-drf3.1
-    - TOX_ENV=py33-django1.8-drf3.2
-    - TOX_ENV=py33-django1.8-drf3.3
-    - TOX_ENV=py33-django1.8-drf3.4
-    - TOX_ENV=py33-django1.8-drf3.5
-    - TOX_ENV=py33-django1.8-drf3.6
-    - TOX_ENV=py33-django1.9-drf3.3
-    - TOX_ENV=py33-django1.9-drf3.4
-    - TOX_ENV=py33-django1.9-drf3.5
-    - TOX_ENV=py33-django1.9-drf3.6
-    - TOX_ENV=py33-django1.10-drf3.4
-    - TOX_ENV=py33-django1.10-drf3.5
-    - TOX_ENV=py33-django1.10-drf3.6
-    - TOX_ENV=py33-django1.10-drf3.7
-    - TOX_ENV=py33-django1.10-drf3.8
-    - TOX_ENV=py33-django1.11-drf3.5
-    - TOX_ENV=py33-django1.11-drf3.6
-    - TOX_ENV=py33-django1.11-drf3.7
-    - TOX_ENV=py33-django1.11-drf3.8
-    - TOX_ENV=py34-django1.8-drf2.4
-    - TOX_ENV=py34-django1.8-drf3.0
-    - TOX_ENV=py34-django1.8-drf3.1
-    - TOX_ENV=py34-django1.8-drf3.2
-    - TOX_ENV=py34-django1.8-drf3.3
-    - TOX_ENV=py34-django1.8-drf3.4
-    - TOX_ENV=py34-django1.8-drf3.5
-    - TOX_ENV=py34-django1.8-drf3.6
-    - TOX_ENV=py34-django1.9-drf3.3
-    - TOX_ENV=py34-django1.9-drf3.4
-    - TOX_ENV=py34-django1.9-drf3.5
-    - TOX_ENV=py34-django1.9-drf3.6
-    - TOX_ENV=py34-django1.10-drf3.4
-    - TOX_ENV=py34-django1.10-drf3.5
-    - TOX_ENV=py34-django1.10-drf3.6
-    - TOX_ENV=py34-django1.10-drf3.7
-    - TOX_ENV=py34-django1.10-drf3.8
-    - TOX_ENV=py34-django1.11-drf3.5
-    - TOX_ENV=py34-django1.11-drf3.6
-    - TOX_ENV=py34-django1.11-drf3.7
-    - TOX_ENV=py34-django1.11-drf3.8
-    - TOX_ENV=py34-django2.0-drf3.7
-    - TOX_ENV=py34-django2.0-drf3.8
-    - TOX_ENV=py35-django2.1-drf3.8
-
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 matrix:
   fast_finish: true
 
 install:
-  - pip install tox
+  - pip install tox tox-travis
 
 script:
-    - tox -e $TOX_ENV
+    - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install tox tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ env:
     - TOX_ENV=py34-django1.11-drf3.8
     - TOX_ENV=py34-django2.0-drf3.7
     - TOX_ENV=py34-django2.0-drf3.8
+    - TOX_ENV=py35-django2.1-drf3.8
 
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ XML support extracted as a third party package directly from the official Django
 
 ## Requirements
 
-* Python (2.7, 3.3, 3.4)
-* Django (1.6 - 1.11, 2.0)
-* Django REST Framework (2.4, 3.0 - 3.8)
+* Python (2.7, 3.4, 3.5, 3.6)
+* Django (1.8 - 1.11, 2.0 - 2.1)
+* Django REST Framework (2.4, 3.0 - 3.9)
 
 This project is tested on the combinations of Python and Django that are supported by each version of Django REST Framework.
 

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
        {py27,py33,py34}-django1.10-drf{3.4,3.5,3.6,3.7,3.8}
        {py27,py33,py34}-django1.11-drf{3.5,3.6,3.7,3.8}
        {py34}-django2.0-drf{3.7,3.8}
+       {py35}-django2.1-drf{3.8}
 
 [testenv]
 commands = ./runtests.py --fast
@@ -21,6 +22,7 @@ deps =
        django1.10: Django==1.10.*
        django1.11: Django==1.11.*
        django2.0: Django==2.0.*
+       django2.1: Django==2.1.*
        drf2.4: djangorestframework==2.4.*
        drf3.0: djangorestframework==3.0.*
        drf3.1: djangorestframework==3.1.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django1.6-drf{2.4,3.0,3.1,3.2}
        {py27,py33,py34}-django1.7-drf{2.4,3.0,3.1,3.2,3.3}
        {py27,py33,py34}-django1.8-drf{2.4,3.0,3.1,3.2,3.3,3.4,3.5,3.6}
        {py27,py33,py34}-django1.9-drf{3.3,3.4,3.5,3.6}
@@ -15,7 +14,6 @@ commands = ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.6: Django==1.6.*
        django1.7: Django==1.7.*
        django1.8: Django==1.8.*
        django1.9: Django==1.9.*

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,11 @@
 envlist =
        py27-{flake8,docs},
        {py27,py34}-django1.8-drf{2.4,3.0,3.1,3.2,3.3,3.4,3.5,3.6}
+       {py35}-django1.8-drf{3.5,3.6}
        {py27,py34}-django1.9-drf{3.3,3.4,3.5,3.6}
+       {py35}-django1.9-drf{3.5,3.6}
        {py27,py34}-django1.10-drf{3.4,3.5,3.6,3.7,3.8}
+       {py35}-django1.10-drf{3.5,3.6,3.7,3.8}
        {py27,py34,py35}-django1.11-drf{3.5,3.6,3.7,3.8}
        {py34,py35}-django2.0-drf{3.7,3.8}
        {py35}-django2.1-drf{3.8}

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django1.8-drf{2.4,3.0,3.1,3.2,3.3,3.4,3.5,3.6}
-       {py27,py33,py34}-django1.9-drf{3.3,3.4,3.5,3.6}
-       {py27,py33,py34}-django1.10-drf{3.4,3.5,3.6,3.7,3.8}
-       {py27,py33,py34}-django1.11-drf{3.5,3.6,3.7,3.8}
+       {py27,py34}-django1.8-drf{2.4,3.0,3.1,3.2,3.3,3.4,3.5,3.6}
+       {py27,py34}-django1.9-drf{3.3,3.4,3.5,3.6}
+       {py27,py34}-django1.10-drf{3.4,3.5,3.6,3.7,3.8}
+       {py27,py34}-django1.11-drf{3.5,3.6,3.7,3.8}
        {py34}-django2.0-drf{3.7,3.8}
        {py35}-django2.1-drf{3.8}
 
@@ -29,7 +29,7 @@ deps =
        drf3.6: djangorestframework==3.6.*
        drf3.7: djangorestframework==3.7.*
        drf3.8: djangorestframework==3.8.*
-       pytest-django==2.8.0
+       pytest-django==3.4.*
 
 [testenv:py27-flake8]
 commands = ./runtests.py --lintonly

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ envlist =
        {py35}-django1.9-drf{3.5,3.6}
        {py27,py34}-django1.10-drf{3.4,3.5,3.6,3.7,3.8}
        {py35}-django1.10-drf{3.5,3.6,3.7,3.8}
-       {py27,py34,py35}-django1.11-drf{3.5,3.6,3.7,3.8}
-       {py34,py35}-django2.0-drf{3.7,3.8}
-       {py35}-django2.1-drf{3.8}
+       {py27,py34,py35}-django1.11-drf{3.5,3.6,3.7,3.8,3.9}
+       {py34,py35}-django2.0-drf{3.7,3.8,3.9}
+       {py35}-django2.1-drf{3.8,3.9}
 
 [testenv]
 commands = ./runtests.py --fast
@@ -32,6 +32,7 @@ deps =
        drf3.6: djangorestframework==3.6.*
        drf3.7: djangorestframework==3.7.*
        drf3.8: djangorestframework==3.8.*
+       drf3.9: djangorestframework==3.9.*
        pytest-django==3.4.*
 
 [testenv:py27-flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,9 @@ envlist =
        {py27,py34}-django1.10-drf{3.4,3.5,3.6,3.7,3.8}
        {py35}-django1.10-drf{3.5,3.6,3.7,3.8}
        {py27,py34,py35}-django1.11-drf{3.5,3.6,3.7,3.8,3.9}
-       {py34,py35}-django2.0-drf{3.7,3.8,3.9}
-       {py35}-django2.1-drf{3.8,3.9}
+       {py36}-django1.11-drf{3.7,3.8,3.9}
+       {py34,py35,py36}-django2.0-drf{3.7,3.8,3.9}
+       {py35,py36}-django2.1-drf{3.8,3.9}
 
 [testenv]
 commands = ./runtests.py --fast

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       {py27,py33,py34}-django1.7-drf{2.4,3.0,3.1,3.2,3.3}
        {py27,py33,py34}-django1.8-drf{2.4,3.0,3.1,3.2,3.3,3.4,3.5,3.6}
        {py27,py33,py34}-django1.9-drf{3.3,3.4,3.5,3.6}
        {py27,py33,py34}-django1.10-drf{3.4,3.5,3.6,3.7,3.8}
@@ -14,7 +13,6 @@ commands = ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.7: Django==1.7.*
        django1.8: Django==1.8.*
        django1.9: Django==1.9.*
        django1.10: Django==1.10.*

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
        {py27,py34}-django1.8-drf{2.4,3.0,3.1,3.2,3.3,3.4,3.5,3.6}
        {py27,py34}-django1.9-drf{3.3,3.4,3.5,3.6}
        {py27,py34}-django1.10-drf{3.4,3.5,3.6,3.7,3.8}
-       {py27,py34}-django1.11-drf{3.5,3.6,3.7,3.8}
-       {py34}-django2.0-drf{3.7,3.8}
+       {py27,py34,py35}-django1.11-drf{3.5,3.6,3.7,3.8}
+       {py34,py35}-django2.0-drf{3.7,3.8}
        {py35}-django2.1-drf{3.8}
 
 [testenv]


### PR DESCRIPTION
This should be supported out of the box, but let's find out...

* [x] Get Django 2.1 passing
* [x] Backfill Python 3.5 support across DRF versions

By the end of this we are going to be at over a hundred different supported combinations. We may want to look into dropping really old combinations from the testing matrix, or cutting some of the middle versions since we don't have much (if any) special casing going on.