### PR TITLE
Removed python 2 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: python
 sudo: false
 
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - pip install tox tox-travis

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Works with Django 3
+
+This is a fork of the jpadilla version of the renderer with no support for python 2.7 which was removed from Django at version 3 thus breaking this module during the import of `django.utils.six` and in other places.
+
 # REST Framework XML
 
 [![build-status-image]][travis]

--- a/rest_framework_xml/parsers.py
+++ b/rest_framework_xml/parsers.py
@@ -6,7 +6,6 @@ import datetime
 import decimal
 
 from django.conf import settings
-from django.utils import six
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import BaseParser
 
@@ -32,7 +31,7 @@ class XMLParser(BaseParser):
         try:
             tree = etree.parse(stream, parser=parser, forbid_dtd=True)
         except (etree.ParseError, ValueError) as exc:
-            raise ParseError('XML parse error - %s' % six.text_type(exc))
+            raise ParseError('XML parse error - %s' % str(exc))
         data = self._xml_convert(tree.getroot())
 
         return data

--- a/rest_framework_xml/renderers.py
+++ b/rest_framework_xml/renderers.py
@@ -3,9 +3,8 @@ Provides XML rendering support.
 """
 from __future__ import unicode_literals
 
-from django.utils import six
+from io import StringIO
 from django.utils.xmlutils import SimplerXMLGenerator
-from django.utils.six.moves import StringIO
 from django.utils.encoding import force_text
 from rest_framework.renderers import BaseRenderer
 
@@ -48,7 +47,7 @@ class XMLRenderer(BaseRenderer):
                 xml.endElement(self.item_tag_name)
 
         elif isinstance(data, dict):
-            for key, value in six.iteritems(data):
+            for key, value in data.items():
                 xml.startElement(key, {})
                 self._to_xml(xml, value)
                 xml.endElement(key)


### PR DESCRIPTION
Django has removed support for python 2.7 so the six imports break when upgrading Django.  I'm going to guess that we probably want to drop support as well.