### PR TITLE
Tested against Django 3.1 and 3.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [pytest]
-strict = true
 addopts = -ra
 testpaths = tests
 filterwarnings =
@@ -20,6 +19,8 @@ envlist =
        lint
        {py35,py36,py37}-django2.2-drf3.11
        {py36,py37,py38}-django3.0-drf3.11
+       {py36,py37,py38}-django3.1-drf3.12
+       {py36,py37,py38}-django3.2-drf3.12
        docs
 isolated_build = True
 
@@ -29,7 +30,10 @@ commands = pytest {posargs}
 deps =
        django2.2: Django==2.2.*
        django3.0: Django==3.0.*
+       django3.1: Django==3.1.*
+       django3.2: Django==3.2.*
        drf3.11: djangorestframework==3.11.*
+       drf3.12: djangorestframework==3.12.*
        pytest-django
 
 


### PR DESCRIPTION
This PR tests the package against Django 3.1 and 3.2 with DRF 3.12.*

cc: @jpadilla 