### PR TITLE
Update renderers.py

### DIFF
--- a/rest_framework_xml/renderers.py
+++ b/rest_framework_xml/renderers.py
@@ -18,6 +18,7 @@ class XMLRenderer(BaseRenderer):
     charset = "utf-8"
     item_tag_name = "list-item"
     root_tag_name = "root"
+    root_attributes = {}
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         """
@@ -30,7 +31,7 @@ class XMLRenderer(BaseRenderer):
 
         xml = SimplerXMLGenerator(stream, self.charset)
         xml.startDocument()
-        xml.startElement(self.root_tag_name, {})
+        xml.startElement(self.root_tag_name, self.root_attributes)
 
         self._to_xml(xml, data)
 


### PR DESCRIPTION
The proposed changes allow to create child classes that include a namespace or other root attributes, e.g.

```
class UrlXmlRenderer(XMLRenderer):
    root_tag_name = 'urlset'
    item_tag_name = 'url'
    root_attributes = {'xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9'}
```