### PR TITLE
Add support official Python & Django versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,11 @@
       strategy:
         matrix:
           platform: ["ubuntu-latest"]
-          python-version: ["3.5", "3.6", "3.7", "3.8"]
+          python-version: ["3.8", "3.9", "3.10", "3.11"]
 
       steps:
-        - uses: "actions/checkout@v2"
-        - uses: "actions/setup-python@v1"
+        - uses: "actions/checkout@v4"
+        - uses: "actions/setup-python@v4"
           with:
             python-version: "${{ matrix.python-version }}"
         - name: "Install dependencies"
@@ -44,10 +44,10 @@
       runs-on: "ubuntu-latest"
 
       steps:
-        - uses: "actions/checkout@v2"
-        - uses: "actions/setup-python@v1"
+        - uses: "actions/checkout@v4"
+        - uses: "actions/setup-python@v4"
           with:
-            python-version: "3.8"
+            python-version: "3.11"
 
         - name: "Install pep517 and twine"
           run: "python -m pip install pep517 twine"
@@ -67,10 +67,10 @@
       runs-on: "${{ matrix.os }}"
 
       steps:
-        - uses: "actions/checkout@v2"
-        - uses: "actions/setup-python@v1"
+        - uses: "actions/checkout@v4"
+        - uses: "actions/setup-python@v4"
           with:
-            python-version: "3.8"
+            python-version: "3.11"
         - name: "Install in dev mode"
           run: "python -m pip install -e .[dev]"
         - name: "Import package"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,25 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 23.9.1
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.11
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
     hooks:
       - id: flake8
-        language_version: python3.8
+        language_version: python3.11
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.4
-    hooks:
-      - id: seed-isort-config
-
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
-        language_version: python3.8
+        language_version: python3.11
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ XML support extracted as a third party package directly from the official Django
 
 ## Requirements
 
-* Python 3.5+
-* Django 2.2+
-* Django REST Framework 3.11+
+* Python 3.8+
+* Django 3.2+
+* Django REST Framework 3.14+
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,9 @@ XML support extracted as a third party package directly from the official Django
 
 ## Requirements
 
-* Python 3.5+
-* Django 2.2+
-* Django REST Framework 3.11+
+* Python 3.8+
+* Django 3.2+
+* Django REST Framework 3.14+
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup(
     cmdclass={"test": PyTest},
     install_requires=install_requires,
     extras_require=extras_requires,
-    python_requires=">=3.5",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -125,10 +125,10 @@ setup(
         "Operating System :: OS Independent",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Internet :: WWW/HTTP",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,8 @@ def pytest_configure():
     )
 
     try:
-        import oauth_provider  # NOQA
         import oauth2  # NOQA
+        import oauth_provider  # NOQA
     except ImportError:
         pass
     else:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-
 from io import StringIO
 
 from django.test import TestCase

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-
 from decimal import Decimal
 from io import StringIO
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,46 +1,41 @@
 [pytest]
-strict = true
 addopts = -ra
 testpaths = tests
 filterwarnings =
     once::Warning
     ignore:::pympler[.*]
 
-
 [gh-actions]
 python =
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38, lint, docs
-
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311, lint, docs
 
 [tox]
 envlist =
-       lint
-       {py35,py36,py37}-django2.2-drf3.11
-       {py36,py37,py38}-django3.0-drf3.11
-       docs
+    lint
+    py{38, 39, 310}-django{3.2, 4.1, 4.2}-drf3.14
+    py{311}-django{4.1, 4.2}-drf3.14
+    docs
 isolated_build = True
-
 
 [testenv]
 commands = pytest {posargs}
 deps =
-       django2.2: Django==2.2.*
-       django3.0: Django==3.0.*
-       drf3.11: djangorestframework==3.11.*
-       pytest-django
-
+    django3.2: Django==3.2.*
+    django4.1: Django==4.1.*
+    django4.2: Django==4.2.*
+    drf3.14: djangorestframework==3.14.*
+    pytest-django
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.11
 extras = dev
-passenv = HOMEPATH  # needed on Windows
+passenv = HOMEPATH                    # needed on Windows
 commands = pre-commit run --all-files
 
-
 [testenv:docs]
-basepython = python3.8
+basepython = python3.11
 extras = docs
 commands = mkdocs build


### PR DESCRIPTION
Hi @jpadilla,

This PR

- adds support for Python 3.9, 3.10 & 3.11
- adds support for Django 3.2, 4.1 & 4.2
- adds support for DRF 3.14
- update GitHub actions
- update pre commit config
- drop support for Python 3.5, 3.6 & 3.7 (EOL)
- drop support for Django 2.2 & 3.0 (EOL)

Please can we have new release after this PR is merged.

Thanks,